### PR TITLE
Added metric meta and ace configs for shovel state metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ For detailed information on this package, please refer to the [online documentat
 
 ### Version next
 
+* Added metric meta and ace configurations for shovel state metric
+
 ### Version 1.2.0
 
 * Adjusted build to use metricly-cli for validation

--- a/analyticConfigurations/ace-rabbitmq.json
+++ b/analyticConfigurations/ace-rabbitmq.json
@@ -35,6 +35,12 @@
           "baseline": false,
           "correlation": false
         }
+      }, {
+        "match": "rabbitmq\\.shovels\\..*\\.state",
+        "properties": {
+          "baseline": false,
+          "correlation": false
+        }
       }
     ],
     "name": "RabbitMQ",

--- a/analyticConfigurations/ace-rabbitmq.json
+++ b/analyticConfigurations/ace-rabbitmq.json
@@ -35,7 +35,8 @@
           "baseline": false,
           "correlation": false
         }
-      }, {
+      },
+      {
         "match": "rabbitmq\\.shovels\\..*\\.state",
         "properties": {
           "baseline": false,

--- a/analyticConfigurations/metric_meta-rabbitmq.json
+++ b/analyticConfigurations/metric_meta-rabbitmq.json
@@ -72,7 +72,8 @@
             "unit": "ops"
           }
         }
-      }, {
+      },
+      {
         "match": "rabbitmq\\.shovels\\..*\\.state",
         "properties": {
           "STATISTIC": "min"

--- a/analyticConfigurations/metric_meta-rabbitmq.json
+++ b/analyticConfigurations/metric_meta-rabbitmq.json
@@ -72,6 +72,11 @@
             "unit": "ops"
           }
         }
+      }, {
+        "match": "rabbitmq\\.shovels\\..*\\.state",
+        "properties": {
+          "STATISTIC": "min"
+        }
       }
     ],
     "name": "RabbitMQ",


### PR DESCRIPTION
A minimum statistic ensures the 5 minute value is always a 0 or 1, and is zero if one or more zeroes appear for raw during an analytics cycle. It doesn't need either band due to its values lacking variability.