### PR TITLE
Added ReplaceWithZero sparseDataStrategy for rabbitmq.cluster.nodes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,22 @@
+## Release History
+
+### Version next
+
+* Added ReplaceWithZero sparseDataStrategy for cluster.nodes
+
+### Version 1.2.1
+
+* Added metric meta and ace configurations for shovel state metric
+
+### Version 1.2.0
+
+* Adjusted build to use metricly-cli for validation
+* Added metric meta and ace configurations for node health metric
+
+### Version 1.1.0
+
+* Updated gridstack for default dashboard
+
+### Version 1.0.0
+
+* Initial production version.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,3 @@
 # netuitive.packages.rabbitmq 1.2.0
 
 For detailed information on this package, please refer to the [online documentation](https://hlp.app.netuitive.com/Content/Integrations/rabbitmq.htm).
-
-## Release History
-
-### Version next
-
-### Version 1.2.1
-
-* Added metric meta and ace configurations for shovel state metric
-
-### Version 1.2.0
-
-* Adjusted build to use metricly-cli for validation
-* Added metric meta and ace configurations for node health metric
-
-### Version 1.1.0
-
-* Updated gridstack for default dashboard
-
-### Version 1.0.0
-
-* Initial production version.

--- a/analyticConfigurations/metric_meta-rabbitmq.json
+++ b/analyticConfigurations/metric_meta-rabbitmq.json
@@ -78,6 +78,12 @@
         "properties": {
           "STATISTIC": "min"
         }
+      },
+      {
+        "match": "rabbitmq\\.cluster\\.nodes",
+        "properties": {
+          "sparseDataStrategy": "ReplaceWithZero"
+        }
       }
     ],
     "name": "RabbitMQ",


### PR DESCRIPTION
When no nodes are reported, let's replace those nulls with zeroes.

Also, updated history and got it out of the Readme.